### PR TITLE
Add pygimli to gostin conda env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ name: gostin
 channels:
   - conda-forge
   - defaults
+  - gimli
 dependencies:
   - verde
   - pooch
@@ -11,6 +12,7 @@ dependencies:
   - rockhound
   - simpeg
   - emg3d
+  - pygimli >=1.1.0
   - ipython
   - jupyter
   - matplotlib


### PR DESCRIPTION
Didn't cause any new conflicts (at least on Linux) and would be necessary to run https://github.com/softwareunderground/gostin/pull/4.